### PR TITLE
Add support for adding annotations to the deployment

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,10 +11,10 @@ metadata:
     app.kubernetes.io/name: {{ .Values.appName }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-    {{- if .Values.annotations }}
-    annotations:
-      {{- toYaml .Values.annotations | nindent 4 }}
-    {{- end }}
+  {{- if .Values.annotations }}
+  annotations:
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,6 +11,10 @@ metadata:
     app.kubernetes.io/name: {{ .Values.appName }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    {{- if .Values.annotations }}
+    annotations:
+      {{- toYaml .Values.annotations | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/values.yaml
+++ b/values.yaml
@@ -24,6 +24,12 @@ githubPat: ""
 # --set runnerLabels="{ label1, label2 }" results in the labels "label1" and "label2".
 runnerLabels: []
 
+# Add annotations to the deployment. This is easist with a values file but can be done on the command line with:
+# --set annotations.<key>=<value> is equivalent to the values file:
+# annotations:
+#   key: value
+annotations: {}
+
 # Adjust replicas depending on your resources available,
 # and how many jobs you want to run concurrently.
 replicas: 1


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
This PR adds a new value to the helm chart that lets users add annotations to the Deployment the chart generates. My motivation/use-case for this was adding annotations for openshift buildconfig triggers (https://docs.openshift.com/container-platform/4.8/openshift_images/triggering-updates-on-imagestream-changes.html) so that the helm deployment would redeploy the pod when I updated my custom runner image. 
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)

No issues but I can open one.

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
I tested this locally on an openshift cluster; it doesn't look like this repo has functional tests I can update.
---
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Updated `templates/deployment.yml` to support an annotations value.
Updated the `values.yml` file to document the new annotations option.
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
