### PR TITLE
GitHub App Authentication Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You can install runners into your cluster using the Helm chart in this repositor
 
 1. Runners can be scoped to an **organization** or a **repository**. Decide what the scope of your runner will be.
     - User-scoped runners are not supported by GitHub.
-2. Create a GitHub Personal Access Token as per the instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runner#pat-guidelines).
+2. Create a GitHub Personal Access Token as per the instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runner#pat-guidelines). Alternatively, create a Github App and install into your org or user account. Instructions are also found in the [image README](https://github.com/redhat-actions/openshift-actions-runners/tree/github_actions#running-with-github-app-authentication)
     - The default `secrets.GITHUB_TOKEN` **does not** have permission to manage self-hosted runners. See [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token).
 3. Add this repository as a Helm repository.
 ```bash
@@ -55,6 +55,10 @@ You can also clone this repository and reference the chart's directory. This all
 export GITHUB_PAT=c0ffeeface1234567890
 # For an org runner, this is the org.
 # For a repo runner, this is the repo owner (org or user).
+# Github App information if you are using Github App auth
+# export GITHUB_APP_ID=123456
+# export GITHUB_APP_INSTALL_ID=123456
+# export GITHUB_APP_PEM='-----RSA Key....'
 export GITHUB_OWNER=redhat-actions
 # For an org runner, omit this argument.
 # For a repo runner, the repo name.
@@ -70,8 +74,19 @@ helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
     --set-string githubRepository=$GITHUB_REPO \
 && echo "---------------------------------------" \
 && helm get manifest $RELEASE_NAME | kubectl get -f -
+
+# For Github App Auth do
+helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
+    --set-string githubAppId=$GITHUB_APP_ID \
+    --set-string githubAppInstallId=$GITHUB_APP_INSTALL_ID \
+    --set-string githubAppPem=$GITHUB_APP_PEM \
+    --set-string githubOwner=$GITHUB_OWNER \
+    --set-string githubRepository=$GITHUB_REPO \
+&& echo "---------------------------------------" \
+&& helm get manifest $RELEASE_NAME | kubectl get -f -
 ```
-5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` on subsequent runs, since it will re-use an existing secret will be left out if it exists already.
+5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` or `githubApp*` strings on subsequent runs, since it will re-use an existing secret.
+
 
 The runners should show up under `Settings > Actions > Self-hosted runners` shortly afterward.
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -61,11 +61,29 @@ spec:
             - name: RUNNER_LABELS
               value: "{{ $taggedImage }},{{- range .Values.runnerLabels }}{{trim .}},{{- end}}"
 
+            {{- if .Values.githubAppId }}
+            - name: GITHUB_APP_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.appSecretName }}
+                  key: {{ .Values.appIdSecretKey}}
+            - name: GITHUB_APP_INSTALL_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.appSecretName }}
+                  key: {{ .Values.appInstallIdSecretKey}}
+            - name: GITHUB_APP_PEM
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.appSecretName }}
+                  key: {{ .Values.appPemSecretKey}}
+            {{- else }}
             - name: GITHUB_PAT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.secretName }}
-                  key: {{ .Values.secretKey }}
+                  name: {{ .Values.patSecretName }}
+                  key: {{ .Values.patSecretKey }}
+            {{- end}}
 
               # Any injected env values from values.yaml will go here
               {{- range .Values.runnerEnv }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -81,8 +81,8 @@ spec:
             - name: GITHUB_PAT
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.patSecretName }}
-                  key: {{ .Values.patSecretKey }}
+                  name: {{ .Values.SecretName }}
+                  key: {{ .Values.SecretKey }}
             {{- end}}
 
               # Any injected env values from values.yaml will go here

--- a/templates/github-app-secret.yml
+++ b/templates/github-app-secret.yml
@@ -1,0 +1,25 @@
+{{- if (not (lookup "v1" "Secret" .Release.Namespace .Values.appSecretName)) }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.appSecretName }}
+  labels:
+    app.kubernetes.io/component: deployment
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.appName }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  # annotations:
+  #    released-at: {{ now | date "02-01-2006 15:04:05 -0700" | quote }}
+type: Opaque
+data:
+  {{- $encodedAppId := (required ".Values.githubAppId must be set" .Values.githubAppId) | b64enc | quote }}
+  {{- $encodedInstallId := (required ".Values.githubAppInstallId must be set" .Values.githubAppInstallId) | b64enc | quote }}
+  {{- $encodedPEM := (required ".Values.githubAppPEM must be set" .Values.githubAppPem) | b64enc | quote }}
+  {{ .Values.appIdSecretKey }}: {{ $encodedAppId }}
+  {{ .Values.appInstallIdSecretKey }}: {{ $encodedInstallId }}
+  {{ .Values.appPemSecretKey }}: {{ $encodedPEM }}
+
+{{- end }}

--- a/templates/pat-secret.yaml
+++ b/templates/pat-secret.yaml
@@ -1,9 +1,9 @@
-{{- if not (lookup "v1" "Secret" .Release.Namespace .Values.secretName) }}
+{{- if and (not (lookup "v1" "Secret" .Release.Namespace .Values.patSecretName)) (.Values.githubPat) (not .Values.githubAppId) }}
 
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.secretName }}
+  name: {{ .Values.patSecretName }}
   labels:
     app.kubernetes.io/component: deployment
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -16,6 +16,6 @@ metadata:
 type: Opaque
 data:
   {{- $encodedPAT := (required ".Values.githubPat must be set" .Values.githubPat) | b64enc | quote }}
-  {{ .Values.secretKey }}: {{ $encodedPAT }}
+  {{ .Values.patSecretKey }}: {{ $encodedPAT }}
 
 {{- end }}

--- a/templates/pat-secret.yaml
+++ b/templates/pat-secret.yaml
@@ -1,9 +1,9 @@
-{{- if and (not (lookup "v1" "Secret" .Release.Namespace .Values.patSecretName)) (.Values.githubPat) (not .Values.githubAppId) }}
+{{- if and (not (lookup "v1" "Secret" .Release.Namespace .Values.SecretName)) (.Values.githubPat) (not .Values.githubAppId) }}
 
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.patSecretName }}
+  name: {{ .Values.SecretName }}
   labels:
     app.kubernetes.io/component: deployment
     app.kubernetes.io/instance: {{ .Release.Name }}
@@ -16,6 +16,6 @@ metadata:
 type: Opaque
 data:
   {{- $encodedPAT := (required ".Values.githubPat must be set" .Values.githubPat) | b64enc | quote }}
-  {{ .Values.patSecretKey }}: {{ $encodedPAT }}
+  {{ .Values.SecretKey }}: {{ $encodedPAT }}
 
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -13,10 +13,10 @@ githubRepository: ""
 githubDomain: ""
 
 # The name of the k8s secret to create for github PAT auth
-SecretName: "github-pat"
+secretName: "github-pat"
 # The name of the key that points to the data within the secret.
 # Modify this to store multiple PATs in one secret.
-SecretKey: "github-pat"
+secretKey: "github-pat"
 # The PAT itself - must be set if the secret is being created.
 githubPat: ""
 

--- a/values.yaml
+++ b/values.yaml
@@ -13,12 +13,27 @@ githubRepository: ""
 githubDomain: ""
 
 # The name of the k8s secret to create.
-secretName: "github-pat"
+patSecretName: "github-pat"
 # The name of the key that points to the data within the secret.
 # Modify this to store multiple PATs in one secret.
-secretKey: "github-pat"
+patSecretKey: "github-pat"
 # The PAT itself - must be set if the secret is being created.
 githubPat: ""
+
+# The name of the Github App k8s secret to create.
+appSecretName: "github-app"
+# The name of the key that points to the Github App ID
+appIdSecretKey: "github-app-id"
+# The name of the key that points to the Github App Install ID
+appInstallIdSecretKey: "github-install-id"
+# The name of the key that points to the Github App PEM
+appPemSecretKey: "github-pem"
+# The Github App Id itself - must be set for Github App Auth
+githubAppId: ""
+# The Github App Install Id itself - must be set for Github App Auth
+githubAppInstallId: ""
+# The Github App PEM itself - must be set for Github App Auth
+githubAppPem: ""
 
 # Pass labels using array syntax, which is curly braces surrounding comma-separated items.
 # --set runnerLabels="{ label1, label2 }" results in the labels "label1" and "label2".

--- a/values.yaml
+++ b/values.yaml
@@ -12,11 +12,11 @@ githubRepository: ""
 # eg. github.mycompany.com
 githubDomain: ""
 
-# The name of the k8s secret to create.
-patSecretName: "github-pat"
+# The name of the k8s secret to create for github PAT auth
+SecretName: "github-pat"
 # The name of the key that points to the data within the secret.
 # Modify this to store multiple PATs in one secret.
-patSecretKey: "github-pat"
+SecretKey: "github-pat"
 # The PAT itself - must be set if the secret is being created.
 githubPat: ""
 


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

This PR adds support for Github App Authentication as defined in the openshift-actions-runners repository (once the PR there is merged). Values are kept the same for github PAT authentication to preserve backwards compatibility but Github App authentication will take precedence if both a PAT and Github App credentials are given.

### Related Issue(s)
This resolves #4
And is directly related to redhat-actions/openshift-actions-runners#12 
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

* Add support for Github App settings in the values.yml
* Add additional github-app k8s secret that is only deployed if secret values are present.
* Modify the deployment.yaml to prefer github app authentication if available.
* Modify the pat-secret.yaml to not deploy if github app authentication is available.
* Update docs for new functionality
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
