### PR TITLE
Add support for organization runner groups

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -61,6 +61,11 @@ spec:
             - name: RUNNER_LABELS
               value: "{{ $taggedImage }},{{- range .Values.runnerLabels }}{{trim .}},{{- end }}"
 
+            {{- if .Values.runnerGroup }}
+            - name: RUNNER_GROUP
+              value: {{ .Values.runnerGroup }}
+            {{- end }}
+
             # App Auth
             {{- if .Values.githubAppId }}
             - name: GITHUB_APP_ID

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,9 @@ githubAppPem: ""
 # --set runnerLabels="{ label1, label2 }" results in the labels "label1" and "label2".
 runnerLabels: []
 
+# The name of an organization runner group name to attach the runner to
+runnerGroup: ""
+
 # Add annotations to the deployment. This is easist with a values file but can be done on the command line with:
 # --set annotations.<key>=<value> is equivalent to the values file:
 # annotations:


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
This adds support for deploying an actions runner with a runner group to the helm chart.
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
Related to redhat-actions/openshift-actions-runners#13
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [x] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

- Updated `templates/deployment.yml` to add the `RUNNER_GROUP` variable to the deployment if available
- Updated `values.yml` to include a runnerGroup option that maps to the `RUNNER_GROUP` variable in the deployment
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
