### PR TITLE
Remove check for pre-existing secret

### DIFF
--- a/templates/github-app-secret.yml
+++ b/templates/github-app-secret.yml
@@ -1,4 +1,4 @@
-{{- if and (not (lookup "v1" "Secret" .Release.Namespace .Values.appSecretName)) (.Values.githubAppId)}}
+{{- if .Values.githubAppId }}
 
 apiVersion: v1
 kind: Secret

--- a/templates/pat-secret.yaml
+++ b/templates/pat-secret.yaml
@@ -1,4 +1,4 @@
-{{- if and (not (lookup "v1" "Secret" .Release.Namespace .Values.secretName)) (.Values.githubPat) }}
+{{- if .Values.githubPat }}
 
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
This PR removes the check for a pre-existing secret in the template for the secret definitions in the chart. This is done because having that check makes helm remove the secret if it already exists.

I've been deploying and redeploying a ton of runners in the past few weeks and was noticing that the secrets created by the chart kept disappearing. I finally realized it was because of that check in the secret template. If you:

* Deploy a release of the chart
* Upgrade the release

The secret created by the initial deployment is gone; so every other run of helm will delete the secret. Not ideal!
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
No related issues
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Removes the check for the created secret from two secret templates.
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
