### PR TITLE
Remove annotation comment because it changes every helm run

### DIFF
--- a/templates/github-app-secret.yml
+++ b/templates/github-app-secret.yml
@@ -11,8 +11,6 @@ metadata:
     app.kubernetes.io/name: {{ .Values.appName }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  # annotations:
-  #    released-at: {{ now | date "02-01-2006 15:04:05 -0700" | quote }}
 type: Opaque
 data:
   {{- $encodedAppId := (required ".Values.githubAppId must be set" .Values.githubAppId) | b64enc | quote }}

--- a/templates/pat-secret.yaml
+++ b/templates/pat-secret.yaml
@@ -11,8 +11,6 @@ metadata:
     app.kubernetes.io/name: {{ .Values.appName }}
     app.kubernetes.io/version: {{ .Chart.Version | quote }}
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
-  # annotations:
-  #    released-at: {{ now | date "02-01-2006 15:04:05 -0700" | quote }}
 type: Opaque
 data:
   {{- $encodedPAT := (required ".Values.githubPat must be set" .Values.githubPat) | b64enc | quote }}


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->
### Description
When testing changes for my previous PR, I was using the helm diff plugin to compare changes between releases. The commented out annotation in the secret template uses a date function so it changes every time helm runs; so helm diff thinks that the secret has changed every time it runs (apparently even comments in templates count).

Since other helm integrations (notably the ansible community.kubernetes.helm module) use helm diff for idempotency checks, those integrations would think that the secret is different every time they run because of that and redeploy the chart when it would be unnecessary.

This PR removes those comments.
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
The option to normalize the yaml in helm diff is merged upstream but hasn't been released yet (databus23/helm-diff#273) so removing this comment seems like a good workaround (since we probably don't need it anyways)
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

Removed the commented out annotation from the secret yaml templates.
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
