### PR TITLE
Add support for ephemeral runners

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -66,6 +66,11 @@ spec:
               value: {{ .Values.runnerGroup }}
             {{- end }}
 
+            {{- if .Values.ephemeral }}
+            - name: EPHEMERAL
+              value: "{{ .Values.ephemeral }}"
+            {{- end }}
+
             # App Auth
             {{- if .Values.githubAppId }}
             - name: GITHUB_APP_ID

--- a/values.yaml
+++ b/values.yaml
@@ -60,6 +60,10 @@ annotations: {}
 # and how many jobs you want to run concurrently.
 replicas: 1
 
+# If these should be registered as ephemeral runners
+# i.e. will quit and restart after running one job
+ephemeral: false
+
 serviceAccountName: default
 
 # Adjust requests and limits depending on your resources,


### PR DESCRIPTION
<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description
This adds support for the `EPHEMERAL` environment variable added to the upstream containers by redhat-actions/openshift-actions-runners#14

It allows the helm chart to deploy actions runners that will restart after every completed job.
<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)
redhat-actions/openshift-actions-runners#14
<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [x] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made
Update the `values.yml` files to support a new `ephemeral` option
Update `templates/deployment.yaml` to set the `EPHEMERAL` environment variable in the deployment if the `ephemeral` option is set.
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
