### PR TITLE
Add nodeSelector and affinity to support dedicated nodes

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,16 @@ spec:
       securityContext:
         runAsNonRoot: true
 
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+
+      {{- if .Values.affinity }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      {{- end }}
+
       volumes:
         # Enable custom cluster PKI
         # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html

--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ runnerGroup: ""
 #   key: value
 annotations: {}
 
-# Add nodeSelector to the deployment. This is easist with a values file but can be done on the command line with:
+# Add nodeSelector to the deployment. This is easiest with a values file but can be done on the command line with:
 # --set nodeSelector.<key>=<value> is equivalent to the values file:
 # Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-selectors.html
 # nodeSelector:

--- a/values.yaml
+++ b/values.yaml
@@ -56,6 +56,17 @@ runnerGroup: ""
 #   key: value
 annotations: {}
 
+# Add nodeSelector to the deployment. This is easist with a values file but can be done on the command line with:
+# --set nodeSelector.<key>=<value> is equivalent to the values file:
+# Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-selectors.html
+# nodeSelector:
+#   key: value
+nodeSelector: {}
+
+# Add affinity to the deployment. This is easist with a values file
+# Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-affinity.html
+affinity: {}
+
 # Adjust replicas depending on your resources available,
 # and how many jobs you want to run concurrently.
 replicas: 1

--- a/values.yaml
+++ b/values.yaml
@@ -56,9 +56,9 @@ runnerGroup: ""
 #   key: value
 annotations: {}
 
+# Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-selectors.html
 # Add nodeSelector to the deployment. This is easiest with a values file but can be done on the command line with:
 # --set nodeSelector.<key>=<value> is equivalent to the values file:
-# Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-selectors.html
 # nodeSelector:
 #   key: value
 nodeSelector: {}


### PR DESCRIPTION
### Description

In a situation where the runner has a dedicated nodepool or needs to be scheduled on a specific node,
the chart needs to support the value for `nodeSelector` or `affinity`.

This PR introduces both of those values.

I know this is too soon an implementation of issue https://github.com/redhat-actions/openshift-actions-runner-chart/issues/19 
But we can always close it or implement different where need be. 

<!--
A short and simple description of what this PR aims to accomplish.
-->

### Related Issue(s)

- ability to schedule runner on specific node/nodepool

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [x] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

  - Change `deployment.yaml`  template adding `nodeSelector` and `affinity` specs
  - Update `values.yaml` adding `nodeSelector`, `affinity` and some links to the documentations
  
<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
