### PR TITLE
Add imagePullSecrets so that image can be pulled from private registry

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -30,6 +30,11 @@ spec:
       securityContext:
         runAsNonRoot: true
 
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -63,6 +63,11 @@ annotations: {}
 #   key: value
 nodeSelector: {}
 
+# Private registries may require keys to read images from them. Specifying
+# ImagePullSecrets on a Pod is the recommended approach to run containers based
+# on images in private registries.
+imagePullSecrets: {}
+
 # Add affinity to the deployment. This is easist with a values file
 # Refer to https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-node-affinity.html
 affinity: {}


### PR DESCRIPTION
### Description

This PR adds support for `imagePullSecrets`, so that images can be pulled from private docker registries.
This is a straight-forward change, I hope the information here is sufficient. 

Reference: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

### Checklist

- [ ] This PR includes a documentation change
- [x] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

 - Updated `Values.yaml` with the new property which defaults to `{}`
 - Updated `deployment.yaml` adding (conditionally) the new property.
