### PR TITLE
Add option for manually-generated Runner Token

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ export GITHUB_PAT=c0ffeeface1234567890
 export GITHUB_APP_ID=123456
 export GITHUB_APP_INSTALL_ID=7890123
 export GITHUB_APP_PEM='----------BEGIN RSA PRIVATE KEY...'
+# OR, Github Runner Token
+export GITHUB_RUNNER_TOKEN=123456
 
 # For an org runner, this is the org.
 # For a repo runner, this is the repo owner (org or user).
@@ -94,6 +96,12 @@ helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
     --set-string githubRepository=$GITHUB_REPO \
 && echo "---------------------------------------" \
 && helm get manifest $RELEASE_NAME | kubectl get -f -
+
+# OR, Installing using Github Runner Token
+helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
+    --set-string githubRunnerToken=$GITHUB_RUNNER_TOKEN \
+    --set-string githubOwner=$GITHUB_OWNER \
+    --set-string githubRepository=$GITHUB_REPO \
 ```
 5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` or `githubApp*` strings on subsequent runs, since the chart will re-use an existing secret.
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
     --set-string githubRunnerToken=$GITHUB_RUNNER_TOKEN \
     --set-string githubOwner=$GITHUB_OWNER \
     --set-string githubRepository=$GITHUB_REPO \
+&& echo "---------------------------------------" \
+&& helm get manifest $RELEASE_NAME | kubectl get -f -
 ```
 5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` or `githubApp*` strings on subsequent runs, since the chart will re-use an existing secret.
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
         {{- end }}
+        {{- if .Values.githubRunnerToken }}
+        - name: home-runner-pv
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}
+        {{- end }}
 
       containers:
         - name: {{ .Release.Name }}
@@ -113,20 +118,12 @@ spec:
                   name: {{ .Values.secretName }}
                   key: {{ .Values.secretKey }}
             {{- end }}
-            # or, github Runner Token
-            {{- if .Values.githubRunnerToken }}
-            - name: RUNNER_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Release.Name }}-{{ .Values.runnerTokenSecretName }}
-                  key: {{ .Values.runnerTokenSecretKey }}
-            {{- end }}
 
-              # Any injected env values from values.yaml will go here
-              {{- range .Values.runnerEnv }}
+            # Any injected env values from values.yaml will go here
+            {{- range .Values.runnerEnv }}
             - name: {{ .name }}
               value: {{ .value }}
-        {{- end }}
+            {{- end }}
 
           securityContext:
 
@@ -155,4 +152,8 @@ spec:
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
+            {{- end }}
+            {{- if .Values.githubRunnerToken }}
+            - name: home-runner-pv
+              mountPath: /home/runner
             {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -113,6 +113,14 @@ spec:
                   name: {{ .Values.secretName }}
                   key: {{ .Values.secretKey }}
             {{- end }}
+            # or, github Runner Token
+            {{- if .Values.githubRunnerToken }}
+            - name: RUNNER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.runnerTokenSecretName }}
+                  key: {{ .Values.runnerTokenSecretKey }}
+            {{- end }}
 
               # Any injected env values from values.yaml will go here
               {{- range .Values.runnerEnv }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -118,7 +118,7 @@ spec:
             - name: RUNNER_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.runnerTokenSecretName }}
+                  name: {{ .Release.Name }}-{{ .Values.runnerTokenSecretName }}
                   key: {{ .Values.runnerTokenSecretKey }}
             {{- end }}
 

--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.githubRunnerToken }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "0"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.volumeSize }}
+  storageClassName: {{ .Values.storageClass }}
+{{ end }}

--- a/templates/register-job.yaml
+++ b/templates/register-job.yaml
@@ -1,0 +1,86 @@
+{{- if .Values.githubRunnerToken }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    # https://helm.sh/docs/chart_best_practices/labels/
+    app.kubernetes.io/component: job
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.appName }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation,hook-failed
+  {{- if .Values.annotations }}
+    {{- toYaml .Values.annotations | nindent 4 }}
+  {{- end }}
+
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ .Release.Name }}-register
+
+          {{- $taggedImage := printf "%s:%s" .Values.runnerImage .Values.runnerTag }}
+          image: {{ $taggedImage }}
+          env:
+            - name: GITHUB_OWNER
+              value: {{ required ".Values.githubOwner must be set." .Values.githubOwner }}
+            - name: GITHUB_REPOSITORY
+              value: {{ .Values.githubRepository }}
+            - name: GITHUB_DOMAIN
+              value: {{ .Values.githubDomain }}
+
+            # The labels must be trimmed. The config script will stop reading labels if it encounters a space.
+            - name: RUNNER_LABELS
+              value: "{{ $taggedImage }},{{- range .Values.runnerLabels }}{{trim .}},{{- end }}"
+
+            {{- if .Values.runnerGroup }}
+            - name: RUNNER_GROUP
+              value: {{ .Values.runnerGroup }}
+            {{- end }}
+
+            {{- if .Values.ephemeral }}
+            - name: EPHEMERAL
+              value: "{{ .Values.ephemeral }}"
+            {{- end }}
+
+            - name: RUNNER_TOKEN
+              value: {{ .Values.githubRunnerToken | quote }}
+
+          command:
+            - bash
+            - '-c'
+            - './register.sh && cp -rT . /mnt'
+
+          volumeMounts:
+            {{- if .Values.clusterPKI }}
+            - name: trusted-ca
+              mountPath: /etc/pki/ca-trust/extracted/pem
+              readOnly: true
+            {{- end }}
+            {{- if .Values.githubRunnerToken }}
+            - name: home-runner-pv
+              mountPath: /mnt
+            {{- end }}
+
+      volumes:
+        # Enable custom cluster PKI
+        # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html
+        {{- if .Values.clusterPKI }}
+        - name: trusted-ca
+          configMap:
+            name: trusted-ca
+            items:
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
+        {{- end }}
+        - name: home-runner-pv
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}
+{{- end }}

--- a/templates/runner-token-secret.yaml
+++ b/templates/runner-token-secret.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.githubRunnerToken }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.runnerTokenSecretName }}
+  labels:
+    app.kubernetes.io/component: deployment
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/name: {{ .Values.appName }}
+    app.kubernetes.io/version: {{ .Chart.Version | quote }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+type: Opaque
+data:
+  {{- $encodedRunnerToken := (required ".Values.githubRunnerToken must be set" .Values.githubRunnerToken) | b64enc | quote }}
+  {{ .Values.runnerTokenSecretKey }}: {{ $encodedRunnerToken }}
+
+{{- end }}

--- a/templates/runner-token-secret.yaml
+++ b/templates/runner-token-secret.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.runnerTokenSecretName }}
+  name: {{ .Release.Name }}-{{ .Values.runnerTokenSecretName }}
   labels:
     app.kubernetes.io/component: deployment
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/values.yaml
+++ b/values.yaml
@@ -42,6 +42,9 @@ githubAppInstallId: ""
 githubAppPem: ""
 
 ### End App Auth
+### Github Runner Token
+runnerTokenSecretName: github-runner-token
+runnerTokenSecretKey: "github-runner-token"
 
 # Pass labels using array syntax, which is curly braces surrounding comma-separated items.
 # --set runnerLabels="{ label1, label2 }" results in the labels "label1" and "label2".

--- a/values.yaml
+++ b/values.yaml
@@ -110,3 +110,7 @@ runnerEnv:
     #   value: http://proxy.example.com:9000
     # - name: no_proxy
     #   value: localhost
+
+# Persistent Volume for /home/runner
+volumeSize: 5Gi
+storageClass: gp2


### PR DESCRIPTION
closes #10

<!--
Please make sure the PR title concisely summarizes your change.
-->

### Description

This change, if applied, add the option to specify manually-generated Runner Token when installing.

### Related Issue(s)

- #10 

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [x] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - Change templates/deployment.yaml  to add the case Runner Token
  - Add templates/runner-token-secret.yaml
  - Change values.yaml to add default name values
  - Update Readme
-->
