### PR TITLE
Persistant volumes in the runner chart

### DIFF
--- a/.github/workflows/helm_lint.yml
+++ b/.github/workflows/helm_lint.yml
@@ -2,6 +2,7 @@ name: Helm Lint
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 env:
   CHART_DIR: .
@@ -9,10 +10,10 @@ env:
 jobs:
   helm_lint:
     name: Helm Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - run: helm lint ${{ env.CHART_DIR }}
 

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -6,13 +6,14 @@ on:
   pull_request:
     paths:
       -'**.md'
+  workflow_dispatch:
 
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/publish_pages.yml
+++ b/.github/workflows/publish_pages.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 env:
   PAGES_BRANCH: release-chart
-  PAGES_URL: https://redhat-actions.github.io/openshift-actions-runner-chart/
+  PAGES_URL: https://boris-ning-usds.github.io/openshift-actions-runner-chart/
   CHART_OUTPUT_DIR: packages/
   CHART_SRC_DIR: .
 

--- a/.github/workflows/publish_pages.yml
+++ b/.github/workflows/publish_pages.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 env:
   PAGES_BRANCH: release-chart
   PAGES_URL: https://redhat-actions.github.io/openshift-actions-runner-chart/
@@ -12,11 +13,11 @@ env:
 jobs:
   package-chart:
     name: Package Helm Chart
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     concurrency: publish
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Helm lint
         run: helm lint ${{ env.CHART_SRC_DIR }}
@@ -73,7 +74,7 @@ jobs:
           echo "CHART_FILENAME=$(basename $CHART_PATH)" >> $GITHUB_ENV
 
       - name: Upload helm chart
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           path: ${{ env.CHART_PATH }}
           name: ${{ env.CHART_FILENAME }}

--- a/README.md
+++ b/README.md
@@ -1,20 +1,26 @@
-# OpenShift GitHub Actions Runner Chart 
+# OpenShift GitHub Actions Runner Chart
 
-[![Helm Lint](https://github.com/redhat-actions/openshift-actions-runner-chart/workflows/Helm%20Lint/badge.svg)](https://github.com/redhat-actions/openshift-actions-runner-chart/actions)
-[![Link checker](https://github.com/redhat-actions/openshift-actions-runner-chart/workflows/Link%20checker/badge.svg)](https://github.com/redhat-actions/openshift-actions-runner-chart/actions)
-[![Publish chart to Pages](https://github.com/redhat-actions/openshift-actions-runner-chart/workflows/Publish%20chart%20to%20Pages/badge.svg)](https://github.com/redhat-actions/openshift-actions-runner-chart/actions)
+[![Helm Lint](https://github.com/boris-ning-usds/openshift-actions-runner-chart/workflows/Helm%20Lint/badge.svg)](https://github.com/boris-ning-usds/openshift-actions-runner-chart/actions)
+[![Link checker](https://github.com/boris-ning-usds/openshift-actions-runner-chart/workflows/Link%20checker/badge.svg)](https://github.com/boris-ning-usds/openshift-actions-runner-chart/actions)
+[![Publish chart to Pages](https://github.com/boris-ning-usds/openshift-actions-runner-chart/workflows/Publish%20chart%20to%20Pages/badge.svg)](https://github.com/boris-ning-usds/openshift-actions-runner-chart/actions)
 
-[![Tag](https://img.shields.io/github/v/tag/redhat-actions/openshift-actions-runner-chart)](https://github.com/redhat-actions/openshift-actions-runner-chart/tags)
+[![Tag](https://img.shields.io/github/v/tag/boris-ning-usds/openshift-actions-runner-chart)](https://github.com/redhat-actions/openshift-actions-runner-chart/tags)
 [![Quay org](https://img.shields.io/badge/quay-redhat--github--actions-red)](https://quay.io/organization/redhat-github-actions)
 
-This repository contains a Helm chart for deploying one or more self-hosted <!-- markdown-link-check-disable --> [GitHub Actions Runners]((https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)) <!-- markdown-link-check-enable -->
+This repository contains a [forked Helm chart](https://github.com/redhat-actions/openshift-actions-runner-chart) for deploying one or more self-hosted <!-- markdown-link-check-disable --> [GitHub Actions Runners](<(https://docs.github.com/en/actions/hosting-your-own-runners/about-self-hosted-runners)>) <!-- markdown-link-check-enable -->
 into a Kubernetes cluster. By default, the container image used is the [**OpenShift Actions Runner**](https://github.com/redhat-actions/openshift-actions-runner).
 
 You can deploy runners automatically in an Actions workflow using the [**OpenShift Actions Runner Installer**](https://github.com/redhat-actions/openshift-actions-runner-installer).
 
 While this chart and the images are developed for and tested on OpenShift, they do not contain any OpenShift specific code and should be compatible with any Kubernetes platform.
 
+## Forked Modifications
+
+- Removed CPU limits from [values.yaml](./values.yaml) and [deployment.yaml](./templates/deployment.yaml) to allow burstable usage of Github action runners.
+- Updated Github actions to use the latest actions.
+
 ## Prerequisites
+
 You must have access to a Kubernetes cluster. Visit [openshift.com/try](https://www.openshift.com/try) or sign up for our [Developer Sandbox](https://developers.redhat.com/developer-sandbox).
 
 You must have Helm 3 installed.
@@ -22,39 +28,43 @@ You must have Helm 3 installed.
 You do **not** need cluster administrator privileges to deploy the runners and run workloads. However, some images or tools may require special permissions.
 
 ## Helm repository
+
 This GitHub repository serves a Helm repository through GitHub Pages.
 
 The repository can be added with:
+
 ```
-helm repo add openshift-actions-runner https://redhat-actions.github.io/openshift-actions-runner-chart
+helm repo add openshift-actions-runner https://boris-ning-usds.github.io/openshift-actions-runner-chart
 ```
 
-The packaged charts can be browsed [here](https://github.com/redhat-actions/openshift-actions-runner-chart/tree/release-chart/packages).
+The packaged charts can be browsed [here](https://github.com/boris-ning-usds/openshift-actions-runner-chart/tree/release-chart/packages).
 
 ## Installing runners
 
 You can install runners into your cluster using the Helm chart in this repository.
 
 1. Runners can be scoped to an **organization** or a **repository**. Decide what the scope of your runner will be.
-    - User-scoped runners are not supported by GitHub.
+   - User-scoped runners are not supported by GitHub.
 2. Determine how you will authorize the runner creation in GitHub. Choose one of the following:
 
-    a. Create a GitHub Personal Access Token as per the PAT instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runner#pat-guidelines).
+   a. Create a GitHub Personal Access Token as per the PAT instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runner#pat-guidelines).
 
-    b. Create a GitHub App and install into your org or user account as per the app instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runners/blob/main/docs/github-app-authentication.md).
+   b. Create a GitHub App and install into your org or user account as per the app instructions in the [runner image README](https://github.com/redhat-actions/openshift-actions-runners/blob/main/docs/github-app-authentication.md).
 
 - Note that the default `secrets.GITHUB_TOKEN` **does not** have permission to manage self-hosted runners. See [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#permissions-for-the-github_token).
 
 3. Add this repository as a Helm repository.
+
 ```bash
 helm repo add openshift-actions-runner \
-    https://redhat-actions.github.io/openshift-actions-runner-chart \
+    https://boris-ning-usds.github.io/openshift-actions-runner-chart \
 && helm repo update
 ```
+
 You can also clone this repository and reference the chart's directory. This allows you to modify the chart if necessary.
 
 4. Install the helm chart, which creates a deployment and a secret. Leave out `githubRepository` if you want an organization-scoped runner.
-    - Add the `--namespace` argument to all `helm` and `kubectl/oc` commands if you want to use a namespace other than your current context's namespace.
+   - Add the `--namespace` argument to all `helm` and `kubectl/oc` commands if you want to use a namespace other than your current context's namespace.
 
 ```bash
 # Authorization from Step 2:
@@ -95,8 +105,8 @@ helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
 && echo "---------------------------------------" \
 && helm get manifest $RELEASE_NAME | kubectl get -f -
 ```
-5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` or `githubApp*` strings on subsequent runs, since the chart will re-use an existing secret.
 
+5. You can re-run step 4 if you want to add runners with different images, labels, etc. You can leave out the `githubPat` or `githubApp*` strings on subsequent runs, since the chart will re-use an existing secret.
 
 The runners should show up under `Settings > Actions > Self-hosted runners` shortly afterward.
 
@@ -107,17 +117,21 @@ You can override the default values such as resource limits and replica counts o
 Refer to the [`values.yaml`](./values.yaml) for values that can be overridden.
 
 ## Using your own runner image
+
 Refer to [Building your own runner image](https://github.com/redhat-actions/openshift-actions-runner/tree/main/base#own-image).
 
 ## GitHub Enterprise Support
+
 Use `--set githubDomain=github.mycompany.com`.
 
 Refer to the [OpenShift Actions Runner README](https://github.com/redhat-actions/openshift-actions-runner#enterprise-support).
 
 ## Managing PATs
+
 See [the wiki](https://github.com/redhat-actions/openshift-actions-runner-chart/wiki/Managing-PATs) for a note on managing mulitple PATs, if you want to add a new PAT or replace an existing one.
 
 ## Troubleshooting
+
 You can view the resources created by Helm using `helm get manifest $RELEASE_NAME`, and then inspect those resources using `kubectl get`.
 
 The resources are also labeled with `app.kubernetes.io/instance={{ .Release.Name }}`, so you can view all the resources with:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ You can deploy runners automatically in an Actions workflow using the [**OpenShi
 
 While this chart and the images are developed for and tested on OpenShift, they do not contain any OpenShift specific code and should be compatible with any Kubernetes platform.
 
+## Deploying New Version
+
+Deploying a new [chart version](https://boris-ning-usds.github.io/openshift-actions-runner-chart) involves manually creating a new tag.
+
+- `git tag` - view all outstanding tags
+- `git tag v1.0.x` - to create a tag for v1.0.x
+- `git push --tags` - to push the new tag for deployment
+
 ## Forked Modifications
 
 - Removed CPU limits from [values.yaml](./values.yaml) and [deployment.yaml](./templates/deployment.yaml) to allow burstable usage of Github action runners.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -126,8 +126,8 @@ spec:
             requests:
               memory: {{ .Values.memoryRequest }}
               cpu: {{ .Values.cpuRequest }}
-            # limits:
-            #   memory: {{ .Values.memoryLimit }}
+            limits:
+              memory: {{ .Values.memoryRequest }}
 
           # Wait until the runner service is actually listening before the pod goes into the Ready state.
           # The entrypoint script takes 5-10s to connect to GitHub and start listening for jobs.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -127,7 +127,7 @@ spec:
               memory: {{ .Values.memoryRequest }}
               cpu: {{ .Values.cpuRequest }}
             limits:
-              memory: {{ .Values.memoryRequest }}
+              memory: {{ .Values.memoryLimit }}
 
           # Wait until the runner service is actually listening before the pod goes into the Ready state.
           # The entrypoint script takes 5-10s to connect to GitHub and start listening for jobs.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -126,8 +126,8 @@ spec:
             requests:
               memory: {{ .Values.memoryRequest }}
               cpu: {{ .Values.cpuRequest }}
-            limits:
-              memory: {{ .Values.memoryLimit }}
+            # limits:
+            #   memory: {{ .Values.memoryLimit }}
 
           # Wait until the runner service is actually listening before the pod goes into the Ready state.
           # The entrypoint script takes 5-10s to connect to GitHub and start listening for jobs.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -128,7 +128,6 @@ spec:
               cpu: {{ .Values.cpuRequest }}
             limits:
               memory: {{ .Values.memoryLimit }}
-              cpu: {{ .Values.cpuLimit }}
 
           # Wait until the runner service is actually listening before the pod goes into the Ready state.
           # The entrypoint script takes 5-10s to connect to GitHub and start listening for jobs.

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -154,5 +154,5 @@ spec:
             {{- end }}
             {{- if .Values.enablePersistantVolume }}
             - name: runner-work-dir
-              mountPath: /home/runner/_work
+              mountPath: {{ .Values.pvVolumePath}}
             {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -56,6 +56,11 @@ spec:
               - key: ca-bundle.crt
                 path: tls-ca-bundle.pem
         {{- end }}
+        {{- if .Values.enablePersistantVolume }}
+        - name: runner-work
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-pvc
+        {{- end }}
 
       containers:
         - name: {{ .Release.Name }}
@@ -146,4 +151,8 @@ spec:
             - name: trusted-ca
               mountPath: /etc/pki/ca-trust/extracted/pem
               readOnly: true
+            {{- end }}
+            {{- if .Values.enablePersistantVolume }}
+            - name: runner-work-dir
+              mountPath: /home/runner/_work
             {{- end }}

--- a/templates/pvc.yml
+++ b/templates/pvc.yml
@@ -1,0 +1,14 @@
+{{- if .Values.enablePersistantVolume }}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-pvc
+spec:
+  accessModes:
+    - {{ .Values.pvAccessModes }}
+  resources:
+    requests:
+      storage: {{ .Values.pvRequestStorage }}
+  storageClassName:  {{ .Values.pvStorageClassName }}  
+  volumeMode: {{ .Values.pvVolumeMode }}  
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -85,10 +85,12 @@ serviceAccountName: default
 # Adjust requests and limits depending on your resources,
 # and how heavyweight your workloads are.
 resources:
-  limits: {}
+  limits: {
+    memory: 256Mi
+  }
   requests:
     cpu: 100m
-    memory: 512Mi
+    memory: 256Mi
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html

--- a/values.yaml
+++ b/values.yaml
@@ -84,10 +84,9 @@ serviceAccountName: default
 
 # Adjust requests and limits depending on your resources,
 # and how heavyweight your workloads are.
-memoryRequest: "512Mi"
-memoryLimit: "1Gi"
-cpuRequest: "100m"
-cpuLimit: "250m"
+resources:
+  limits: {}
+  requests: {}
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html

--- a/values.yaml
+++ b/values.yaml
@@ -86,7 +86,9 @@ serviceAccountName: default
 # and how heavyweight your workloads are.
 resources:
   limits: {}
-  requests: {}
+  requests:
+    cpu: 100m
+    memory: 512Mi
 
 # Enable custom cluster PKI loading
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html

--- a/values.yaml
+++ b/values.yaml
@@ -96,6 +96,12 @@ resources:
 # https://docs.openshift.com/container-platform/4.6/networking/configuring-a-custom-pki.html
 clusterPKI: false
 
+enablePersistantVolume: false
+pvRequestStorage: 10Gi
+pvStorageClassName: azure-4-file
+pvAccessModes: ReadWriteMany
+pvVolumeMode: Filesystem 
+
 # You can inject arbitrary environment variables here:
 runnerEnv:
     # - name: ENV_VAR

--- a/values.yaml
+++ b/values.yaml
@@ -101,6 +101,7 @@ pvRequestStorage: 10Gi
 pvStorageClassName: azure-4-file
 pvAccessModes: ReadWriteMany
 pvVolumeMode: Filesystem 
+pvVolumePath: "/home/runner/_work" 
 
 # You can inject arbitrary environment variables here:
 runnerEnv:


### PR DESCRIPTION
### Description

Adding a persistent volume claim will allow us to expand the `/home/runner/_work` directory while building large images

### Checklist

- [ ] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [ ] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
