### PR TITLE
Add explict setting for APP vs PAT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ You can also clone this repository and reference the chart's directory. This all
 ```bash
 # Authorization from Step 2:
 # Either GITHUB_PAT, OR all 3 of GITHUB_APP_*
+export AUTH_TYPE=pat
 export GITHUB_PAT=c0ffeeface1234567890
 # OR, GitHub App information:
+export AUTH_TYPE=app
 export GITHUB_APP_ID=123456
 export GITHUB_APP_INSTALL_ID=7890123
 export GITHUB_APP_PEM='----------BEGIN RSA PRIVATE KEY...'
@@ -79,6 +81,7 @@ export RELEASE_NAME=actions-runner
 
 # Installing using PAT Auth
 helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
+    --set-string authType=$AUTH_TYPE \
     --set-string githubPat=$GITHUB_PAT \
     --set-string githubOwner=$GITHUB_OWNER \
     --set-string githubRepository=$GITHUB_REPO \
@@ -87,6 +90,7 @@ helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
 
 # OR, Installing using App Auth
 helm install $RELEASE_NAME openshift-actions-runner/actions-runner \
+    --set-string authType=$AUTH_TYPE \
     --set-string githubAppId=$GITHUB_APP_ID \
     --set-string githubAppInstallId=$GITHUB_APP_INSTALL_ID \
     --set-string githubAppPem="$GITHUB_APP_PEM" \

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -87,7 +87,7 @@ spec:
             {{- end }}
 
             # App Auth
-            {{- if .Values.githubAppId }}
+            {{- if eq .Values.authType "app" }}
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
@@ -106,7 +106,7 @@ spec:
             {{- end }}
 
             # or, PAT Auth
-            {{- if .Values.githubPat }}
+             {{- if eq .Values.authType "pat" }}
             - name: GITHUB_PAT
               valueFrom:
                 secretKeyRef:

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,9 @@ githubRepository: ""
 # eg. github.mycompany.com
 githubDomain: ""
 
+# Set to either "app" for GitHub App Auth, or "pat" for PAT Auth. See the sections below for config of each
+authType: app
+
 ### Values for PAT Auth
 ### Refer to https://github.com/redhat-actions/openshift-actions-runners#pat-guidelines
 


### PR DESCRIPTION

### Description

I don't want the helm chart to manage the secret with PAT/APP details, because I manage secrets via sealedSecrets.
In theory this is fine, as I can just leave `githubPat` and `githubApp*` values blanks and the chart won't create the secret and I can just refer to an existing secret.

But the condition if to include the GITHUB_APP* or GITHUB_PAT env vars in the Deployment is conditional on one of these being set. So this makes it impossible to include the env vars without it also managing the secret.

The approach I've taken here is to create a new value: `authType`, which is either `app` or `pat`. This is used to decide which env vars to expose. This allows us to expose an externally managed secret for either.

But this will be a breaking change, as every user will need to set this value. Not sure if there's a better way to manage this?

### Related Issue(s)

<!--
A List of Issues this PR aims to fix or is related to.
-->

### Checklist

- [x] This PR includes a documentation change
- [ ] This PR does not need a documentation change
---
- [ ] This PR includes test changes
- [ ] This PR's changes are already tested
---
- [ ] This change is not user-facing
- [ ] This change is a patch change
- [ ] This change is a minor change
- [x] This change is a major (breaking) change

### Changes made

<!--
A list of changes within this PR
  - Change component A
  - Update dependency B
  - Fix function C
  - Remove deprecated function D
-->
